### PR TITLE
Add release docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Publish Documentation
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish docs for (e.g., v1.2.3)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install package and docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict -f docs/mkdocs.yml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          cname: vhrharmonize.sefa.ai

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: vhrharmonize
 site_description: WorldView preprocessing library and CLI documentation
-site_url: https://example.com/vhrharmonize
+site_url: https://vhrharmonize.sefa.ai/
 repo_url: https://github.com/cankanoa/vhrharmonize
 repo_name: cankanoa/vhrharmonize
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to publish the MkDocs documentation when a version tag release is created.

## Changes

  - Adds `.github/workflows/docs.yml` to build and deploy docs on `v*.*.*` tag pushes.
  - Keeps PyPI publishing separate and unchanged.
  - Supports manual docs publishing through `workflow_dispatch` with an optional tag.
  - Deploys the generated site to GitHub Pages using `peaceiris/actions-gh-pages`.
  - Sets the GitHub Pages custom domain to `vhrharmonize.sefa.ai`.
  - Updates `docs/mkdocs.yml` so `site_url` points to the production docs domain.

## Validation

  - Confirmed the staged diff only included the docs workflow and MkDocs config update.
  - Ran `git diff --check` successfully.